### PR TITLE
Updated handler from prometheus to promhttp, along with import

### DIFF
--- a/json2prom.go
+++ b/json2prom.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+    "github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var client = &http.Client{
@@ -54,7 +55,7 @@ func main() {
 	http.Handle("/", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte(`<html><head><title>json2prom</title></head><body><h1>json2prom</h1><p><a href="/metrics">Metrics</a></p></body></html>`))
 	}))
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	addr := os.Getenv("HTTP_ADDR")
 	if addr == "" {

--- a/json2prom.go
+++ b/json2prom.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var client = &http.Client{
@@ -54,7 +55,7 @@ func main() {
 	http.Handle("/", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		resp.Write([]byte(`<html><head><title>json2prom</title></head><body><h1>json2prom</h1><p><a href="/metrics">Metrics</a></p></body></html>`))
 	}))
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 
 	addr := os.Getenv("HTTP_ADDR")
 	if addr == "" {


### PR DESCRIPTION
Assume due to changes in prometheus client_golang, the prometheus.Handler was no longer valid.